### PR TITLE
Update to 1.19.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
-	modImplementation "fi.dy.masa.malilib:malilib-fabric-1.19.3:${project.malilib_version}"
+	modImplementation "fi.dy.masa.malilib:malilib-fabric-1.19.4:${project.malilib_version}"
 	modImplementation "com.github.DarkKronicle:AdvancedChatCore:${project.advancedchat_version}"
 
 	implementation 'org.openjdk.nashorn:nashorn-core:15.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.2
-loader_version=0.14.11
-fabric_api_version=0.68.1+1.19.3
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.1
+loader_version=0.14.18
+fabric_api_version=0.76.0+1.19.4
 
-mod_version=1.2.7
+mod_version=1.2.8
 maven_group=io.github.darkkronicle
 archives_base_name=AdvancedChatFilters
 
-malilib_version = 0.14.0
+malilib_version = 0.15.2
 org.gradle.jvmargs=-Xmx1G
-advancedchat_version=v1.5.9
+advancedchat_version=v1.5.10
 owo_version=2.0.0
 
 # publishing

--- a/src/main/java/io/github/darkkronicle/advancedchatfilters/config/gui/GuiFilterEditor.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatfilters/config/gui/GuiFilterEditor.java
@@ -178,7 +178,7 @@ public class GuiFilterEditor extends GuiBase {
 
         y += this.addLabel(x, y, filter.getReplaceType().config) + 2;
         replaceTypeWidget = new WidgetDropDownList<>(x, y, 100, 20, 200, 10, ImmutableList.copyOf(MatchReplaceRegistry.getInstance().getAll()), MatchReplaceRegistry.MatchReplaceOption::getDisplayName);
-        replaceTypeWidget.setZLevel(getZOffset() + 100);
+        replaceTypeWidget.setZLevel(replaceTypeWidget.getHeight() + 100);
         replaceTypeWidget.setSelectedEntry((MatchReplaceRegistry.MatchReplaceOption) filter.getReplaceType().config.getOptionListValue());
         this.addWidget(replaceTypeWidget);
         y += stripColors.getHeight() + 4;

--- a/src/main/java/io/github/darkkronicle/advancedchatfilters/config/gui/SharingScreen.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatfilters/config/gui/SharingScreen.java
@@ -50,12 +50,12 @@ public class SharingScreen extends GuiBase {
         text.setMaxLength(12800);
         if (starting != null) {
             text.setText(starting);
-            text.setTextFieldFocused(true);
+            text.setFocused(true);
         }
-        text.changeFocus(true);
+        text.setFocused(true);
         text.setDrawsBackground(true);
         text.setEditable(true);
-        text.changeFocus(true);
+        text.setFocused(true);
         this.addTextField(text, null);
         String filterName = ButtonListener.Type.IMPORT_FILTER.getDisplayName();
         int filterWidth = StringUtils.getStringWidth(filterName) + 10;

--- a/src/main/java/io/github/darkkronicle/advancedchatfilters/filters/processors/SoundProcessor.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatfilters/filters/processors/SoundProcessor.java
@@ -190,7 +190,7 @@ public class SoundProcessor implements IMatchProcessor, IJsonApplier, IScreenSup
                             10,
                             ImmutableList.copyOf(Filter.NotifySound.values()),
                             Filter.NotifySound::getDisplayName);
-            this.widgetDropDown.setZLevel(this.getZOffset() + 100);
+            this.widgetDropDown.setZLevel(this.widgetDropDown.getHeight() + 100);
             this.setTitle(StringUtils.translate("advancedchatfilters.screen.sound"));
         }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,11 +20,11 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.13.0",
+    "fabricloader": ">=0.14.18",
     "fabric": "*",
-    "minecraft": ">=1.19.3",
-    "malilib": ">=0.13.0",
-    "advancedchatcore": ">=1.4.0-1.18"
+    "minecraft": ">=1.19.4",
+    "malilib": ">=0.15.2",
+    "advancedchatcore": ">=1.5.10-1.18"
   },
   "custom": {
     "acmodule": true,


### PR DESCRIPTION
This pull request updates the mod to run on Minecraft 1.19.4.

Only minimal changes seem to be required. I've bumped the version up to 1.2.8

Depends on https://github.com/DarkKronicle/AdvancedChatCore/pull/63